### PR TITLE
Feature: Commands API support.

### DIFF
--- a/examples/process_commands.rb
+++ b/examples/process_commands.rb
@@ -1,0 +1,106 @@
+#! /usr/bin/env ruby
+
+##
+# This example demonstrates a basic command-driven application.
+#
+# It has a method called process_commands that executes and the given command.
+# Each command is acknowledged by either the #process! or #reject! method.
+#
+# This example application supports three basic commands:
+#   SAY    - print the message given in the command data field "message".
+#   REPORT - respond with a report containing the public IP and process ID.
+#   KILL   - send the given "signal" (or SIGTERM by default) to the given "pid".
+#
+# Upon startup, it queries the M2X API to check for any outstanding
+# unacknowledged commands for the current device and processes them.
+# After that, it enters a loop of processing each new command as it arrives
+# via command delivery notifications. A more robust application would also
+# periodically query the M2X API to check for outstanding commands again,
+# as it is possible to miss delivery notifications in a network partition.
+
+require "m2x/mqtt"
+
+API_KEY = ENV.fetch("API_KEY")
+DEVICE  = ENV.fetch("DEVICE")
+
+puts "M2X::MQTT/#{M2X::MQTT::VERSION} Commands example"
+
+# The list of supported commands
+ALLOWED_COMMANDS = %w(SAY REPORT KILL)
+
+# Method to process (or reject) a given command.
+def process_command(command)
+  name = command["name"].upcase
+
+  unless ALLOWED_COMMANDS.include?(name)
+    reason = "unknown command name; allowed commands are: #{ALLOWED_COMMANDS}"
+    return command.reject!(reason: reason)
+  end
+
+  case name
+  when "SAY"
+    message = command["data"]["message"]
+
+    return command.reject!(reason: "'message' data is required") unless message
+
+    puts "SAY: #{message}"
+
+    command.process!
+  when "REPORT"
+    report = {
+      public_ip: `curl -s ifconfig.co`.strip,
+      pid:       Process.pid.to_s
+    }
+
+    puts "REPORT: #{report.inspect}"
+
+    command.process!(report)
+  when "KILL"
+    signal = command["data"]["signal"]       || "TERM"
+    pid    = Integer(command["data"]["pid"]) || Process.pid
+
+    Process.kill(signal, pid)
+
+    puts "KILL: #{signal} #{pid}"
+
+    command.process!(signal: signal, pid: pid.to_s)
+  end
+
+rescue => e
+  command.reject!(exception: e.class, message: e.message, backtrace: e.backtrace.join("\n"))
+  raise
+end
+
+# Method to check the response from the M2X API.
+def check_response(client)
+  res = client.get_response
+
+  warn "M2X API error response: status: #{res}" unless res["status"] < 400
+end
+
+# Create an API client.
+m2x = M2X::MQTT.new(API_KEY)
+m2x.client.subscribe
+
+# Get the device.
+device = m2x.device(DEVICE)
+
+# List any commands sent to the device but still unacknowledged.
+commands = device.commands(status: "sent")
+
+# Process each command from the unacknowledged list (starting with the oldest).
+commands.reverse_each do |command|
+  # Fetch the entire detailed view of the command, including data.
+  # This is necessary because the list returns the summary view of each command.
+  command.refresh
+
+  # Process the command.
+  process_command(command)
+  check_response(m2x.client)
+end
+
+# Wait for more command notifications, processing them as they arrive.
+m2x.client.get_command do |command|
+  process_command(command)
+  check_response(m2x.client)
+end

--- a/lib/m2x/mqtt.rb
+++ b/lib/m2x/mqtt.rb
@@ -7,6 +7,7 @@ module M2X
     require_relative "mqtt/device"
     require_relative "mqtt/distribution"
     require_relative "mqtt/stream"
+    require_relative "mqtt/command"
 
     attr_accessor :client
 

--- a/lib/m2x/mqtt.rb
+++ b/lib/m2x/mqtt.rb
@@ -2,6 +2,7 @@ module M2X
   class MQTT
     require_relative "mqtt/version"
     require_relative "mqtt/client"
+    require_relative "mqtt/client/packet_router"
     require_relative "mqtt/resource"
     require_relative "mqtt/device"
     require_relative "mqtt/distribution"

--- a/lib/m2x/mqtt/client.rb
+++ b/lib/m2x/mqtt/client.rb
@@ -82,15 +82,17 @@ class M2X::MQTT::Client
     mqtt_client.subscribe(command_topic)
 
     unless block_given?
-      topic, json = json_fetch_any(mqtt_client)
+      topic, payload = json_fetch_any(mqtt_client)
+      payload = Command.new(self, payload)
 
-      return json
+      return payload
     end
 
     loop do
-      topic, json = json_fetch_any(mqtt_client)
+      topic, payload = json_fetch_any(mqtt_client)
+      payload = Command.new(self, payload)
 
-      yield json
+      yield payload
     end
   end
 

--- a/lib/m2x/mqtt/client.rb
+++ b/lib/m2x/mqtt/client.rb
@@ -65,10 +65,10 @@ class M2X::MQTT::Client
   def get_command
     mqtt_client.subscribe(command_topic)
 
-    return packet_router.json_fetch(mqtt_client, command_topic) unless block_given?
+    return M2X::MQTT::Command.new(self, packet_router.json_fetch(mqtt_client, command_topic)) unless block_given?
 
     loop do
-      yield packet_router.json_fetch(mqtt_client, command_topic)
+      yield M2X::MQTT::Command.new(self, packet_router.json_fetch(mqtt_client, command_topic))
     end
   end
 
@@ -83,7 +83,7 @@ class M2X::MQTT::Client
 
     unless block_given?
       topic, payload = json_fetch_any(mqtt_client)
-      payload = Command.new(self, payload)
+      payload = M2X::MQTT::Command.new(self, payload)
 
       return payload
     end

--- a/lib/m2x/mqtt/client.rb
+++ b/lib/m2x/mqtt/client.rb
@@ -72,30 +72,6 @@ class M2X::MQTT::Client
     end
   end
 
-  # Public: Retrieve either a repsonse or a command from the M2X Server.
-  #
-  # Returns a Hash with the response or command from the MQTT Server in M2X.
-  # Optionally receives a block which will iterate through commands
-  # and yield each one.
-  def get_response_or_command
-    mqtt_client.subscribe(response_topic)
-    mqtt_client.subscribe(command_topic)
-
-    unless block_given?
-      topic, payload = json_fetch_any(mqtt_client)
-      payload = M2X::MQTT::Command.new(self, payload)
-
-      return payload
-    end
-
-    loop do
-      topic, payload = json_fetch_any(mqtt_client)
-      payload = Command.new(self, payload)
-
-      yield payload
-    end
-  end
-
   [:get, :post, :put, :delete, :head, :options, :patch].each do |verb|
     define_method verb do |path, params=nil|
       request(verb, path, params)

--- a/lib/m2x/mqtt/client.rb
+++ b/lib/m2x/mqtt/client.rb
@@ -20,11 +20,12 @@ class M2X::MQTT::Client
 
   # Public: Subscribe the client to the responses topic.
   #
-  # This is required in order to receive responses from the
-  # M2X API server. Note that #get_response already subscribes
-  # the client.
+  # This is required in order to receive responses or commands
+  # from the M2X API server. Note that #get_response already
+  # subscribes the client.
   def subscribe
     mqtt_client.subscribe(response_topic)
+    mqtt_client.subscribe(command_topic)
   end
 
   # Public: Send a payload to the M2X API server.
@@ -83,6 +84,10 @@ class M2X::MQTT::Client
 
   def response_topic
     @response_topic ||= "m2x/#{@api_key}/responses".freeze
+  end
+
+  def command_topic
+    @command_topic ||= "m2x/#{@api_key}/commands".freeze
   end
 
   def mqtt_client

--- a/lib/m2x/mqtt/client/packet_router.rb
+++ b/lib/m2x/mqtt/client/packet_router.rb
@@ -21,24 +21,7 @@ class M2X::MQTT::Client::PacketRouter
     end
   end
 
-  def fetch_any(mqtt_client, topic)
-    @lock.synchronize do
-      @queues.each do |queue|
-        packet = queue.pop
-        return packet if packet
-      end
-
-      mqtt_client.get_packet
-    end
-  end
-
   def json_fetch(mqtt_client, topic)
     JSON.parse(fetch(mqtt_client, topic).payload)
-  end
-
-  def json_fetch_any(mqtt_client)
-    packet = fetch_any(mqtt_client)
-
-    return [packet.topic, JSON.parse(packet.payload)]
   end
 end

--- a/lib/m2x/mqtt/client/packet_router.rb
+++ b/lib/m2x/mqtt/client/packet_router.rb
@@ -1,0 +1,44 @@
+require "json"
+require "thread"
+
+class M2X::MQTT::Client::PacketRouter
+  def initialize
+    @lock   = Mutex.new
+    @queues = Hash.new { |hash, key| hash[key] = [] }
+  end
+
+  def fetch(mqtt_client, topic)
+    @lock.synchronize do
+      packet = @queues[topic].pop
+      return packet if packet
+
+      loop do
+        packet = mqtt_client.get_packet
+        return packet if topic == packet.topic
+
+        @queues[packet.topic] << packet
+      end
+    end
+  end
+
+  def fetch_any(mqtt_client, topic)
+    @lock.synchronize do
+      @queues.each do |queue|
+        packet = queue.pop
+        return packet if packet
+      end
+
+      mqtt_client.get_packet
+    end
+  end
+
+  def json_fetch(mqtt_client, topic)
+    JSON.parse(fetch(mqtt_client, topic).payload)
+  end
+
+  def json_fetch_any(mqtt_client)
+    packet = fetch_any(mqtt_client)
+
+    return [packet.topic, JSON.parse(packet.payload)]
+  end
+end

--- a/lib/m2x/mqtt/client/packet_router.rb
+++ b/lib/m2x/mqtt/client/packet_router.rb
@@ -9,7 +9,7 @@ class M2X::MQTT::Client::PacketRouter
 
   def fetch(mqtt_client, topic)
     @lock.synchronize do
-      packet = @queues[topic].pop
+      packet = @queues[topic].shift
       return packet if packet
 
       loop do

--- a/lib/m2x/mqtt/command.rb
+++ b/lib/m2x/mqtt/command.rb
@@ -1,0 +1,31 @@
+require "uri"
+
+# Wrapper for AT&T M2X Commands API
+# https://m2x.att.com/developer/documentation/v2/device
+class M2X::MQTT::Command < M2X::MQTT::Resource
+
+  def initialize(client, attributes)
+    @client     = client
+    @attributes = attributes
+  end
+
+  def path
+    @path ||= URI.parse(@attributes.fetch("url")).path
+  end
+
+  # Mark the command as processed, with optional response data.
+  # Check the API response after calling to verify success (no status conflict).
+  #
+  # https://m2x.att.com/developer/documentation/v2/commands#Device-Marks-a-Command-as-Processed
+  def process!(response_data={})
+    @client.post("#{path}/process", response_data)
+  end
+
+  # Mark the command as rejected, with optional response data.
+  # Check the API response after calling to verify success (no status conflict).
+  #
+  # https://m2x.att.com/developer/documentation/v2/commands#Device-Marks-a-Command-as-Rejected
+  def reject!(response_data={})
+    @client.post("#{path}/reject", response_data)
+  end
+end

--- a/lib/m2x/mqtt/device.rb
+++ b/lib/m2x/mqtt/device.rb
@@ -23,6 +23,26 @@ class M2X::MQTT::Device < M2X::MQTT::Resource
     M2X::MQTT::Stream.new(@client, self, "name" => name)
   end
 
+  # Return a list of recently received commands.
+  #
+  # Most commonly, this method can be used to fetch unacknowledged
+  # commands by filtering by delivery status, using the parameters:
+  #
+  # { status: "sent" }
+  #
+  # MQTT clients that are subscribed to command delivery notifications
+  # should still use this method periodically to check for unacknowledged
+  # commands that were missed while offline or during a network partition.
+  #
+  # https://m2x.att.com/developer/documentation/v2/commands#Device-List-of-Received-Commands
+  def commands(params={})
+    @client.get("#{path}/commands", params)
+
+    commands = @client.get_response["commands"]
+
+    commands && commands.map { |data| Command.new(@client, data) }
+  end
+
   # Update the current location of the specified device.
   #
   # https://m2x.att.com/developer/documentation/v2/device#Update-Device-Location

--- a/lib/m2x/mqtt/device.rb
+++ b/lib/m2x/mqtt/device.rb
@@ -38,9 +38,10 @@ class M2X::MQTT::Device < M2X::MQTT::Resource
   def commands(params={})
     @client.get("#{path}/commands", params)
 
-    commands = @client.get_response["commands"]
+    res      = @client.get_response
+    commands = res["body"]["commands"] if res["status"] < 300
 
-    commands && commands.map { |data| Command.new(@client, data) }
+    commands.map { |data| M2X::MQTT::Command.new(@client, data) } if commands
   end
 
   # Update the current location of the specified device.

--- a/lib/m2x/mqtt/resource.rb
+++ b/lib/m2x/mqtt/resource.rb
@@ -21,4 +21,19 @@ class M2X::MQTT::Resource
   def path
     raise NotImplementedError
   end
+
+  # Return the resource details
+  def view
+    @client.get(path)
+
+    res = @client.get_response
+
+    @attributes = res["body"] if res["status"] < 300 && res["body"]
+  end
+
+  # Refresh the resource details and return self
+  def refresh
+    view
+    self
+  end
 end


### PR DESCRIPTION
This PR adds support for the Commands API, including receiving command delivery notifications directly through MQTT.

Note that I had to introduce an inner abstraction the `PacketRouter` because the `mqtt` gem does not provide a way of pulling out packets by topic.

There may be some aspects of this design that could be improved (so don't hesitate to speak up about them), but I think this PR serves as a good starting place. 