### PR TITLE
Fix examples of `status: "sent"` to use `status: "pending"`.

### DIFF
--- a/examples/process_commands.rb
+++ b/examples/process_commands.rb
@@ -86,7 +86,7 @@ m2x.client.subscribe
 device = m2x.device(DEVICE)
 
 # List any commands sent to the device but still unacknowledged.
-commands = device.commands(status: "sent")
+commands = device.commands(status: "pending")
 
 # Process each command from the unacknowledged list (starting with the oldest).
 commands.reverse_each do |command|

--- a/lib/m2x/mqtt/device.rb
+++ b/lib/m2x/mqtt/device.rb
@@ -28,7 +28,7 @@ class M2X::MQTT::Device < M2X::MQTT::Resource
   # Most commonly, this method can be used to fetch unacknowledged
   # commands by filtering by delivery status, using the parameters:
   #
-  # { status: "sent" }
+  # { status: "pending" }
   #
   # MQTT clients that are subscribed to command delivery notifications
   # should still use this method periodically to check for unacknowledged


### PR DESCRIPTION
This PR fixes the examples querying for the list of commands with `status: "sent"` to instead use `status: "pending"`.